### PR TITLE
AIPM: Move "delete" Buttonon "user Story" Panel, Beside Of "develop With Codex" Button

### DIFF
--- a/apps/frontend/public/app.js
+++ b/apps/frontend/public/app.js
@@ -2738,8 +2738,10 @@ function renderDetails() {
   form.innerHTML = `
     <div class="form-toolbar">
       <button type="button" class="secondary" id="edit-story-btn">Edit Story</button>
-      <button type="button" class="secondary" id="codex-delegate-btn">Develop with Codex</button>
-      <button type="button" class="danger" id="delete-story-btn">Delete</button>
+      <div class="form-toolbar__actions" role="group" aria-label="Story actions">
+        <button type="button" class="danger" id="delete-story-btn">Delete</button>
+        <button type="button" class="secondary" id="codex-delegate-btn">Develop with Codex</button>
+      </div>
     </div>
     <div class="full field-row">
       <label>Title</label>

--- a/apps/frontend/public/styles.css
+++ b/apps/frontend/public/styles.css
@@ -826,6 +826,24 @@ body.is-mindmap-panning {
   background: #ffffff;
 }
 
+.form-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.form-toolbar__actions {
+  margin-left: auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.form-toolbar__actions > button {
+  flex: 0 0 auto;
+}
+
 .form-actions {
   display: flex;
   gap: 0.75rem;
@@ -1818,5 +1836,24 @@ dialog[data-size='content'] .modal-shell {
   }
   .panel {
     min-height: 300px;
+  }
+}
+
+@media (max-width: 640px) {
+  .form-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .form-toolbar__actions {
+    margin-left: 0;
+    width: 100%;
+    justify-content: flex-start;
+    gap: 0.5rem;
+  }
+
+  .form-toolbar__actions > button {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- group the Delete and Develop with Codex buttons in the user story form toolbar so Delete sits immediately to the left of the Codex action
- add responsive toolbar styling to keep the actions aligned on desktop and mobile widths

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690622d1de0883338b9218b7409ad63f