### PR TITLE
AIPM: When Delegate To Codex, I Want To Get Link To Codex (ex. Https://chatgpt.com/codex/tasks/task_e_69084262b7b4833392669e7…

### DIFF
--- a/apps/frontend/public/app.js
+++ b/apps/frontend/public/app.js
@@ -1001,6 +1001,14 @@ function ensureCodexEntryShape(entry, storyId) {
   normalized.latestStatus = normalized.latestStatus ?? null;
   normalized.lastCheckedAt = normalized.lastCheckedAt ?? null;
   normalized.lastError = normalized.lastError ?? null;
+  normalized.codexTaskUrl =
+    typeof normalized.codexTaskUrl === 'string' && normalized.codexTaskUrl.trim().length > 0
+      ? normalized.codexTaskUrl.trim()
+      : null;
+  normalized.confirmationCode =
+    typeof normalized.confirmationCode === 'string' && normalized.confirmationCode.trim().length >= 6
+      ? normalized.confirmationCode.trim()
+      : null;
   if (normalized.targetNumber != null && normalized.targetNumber !== '') {
     const parsed = Number(normalized.targetNumber);
     normalized.targetNumber = Number.isFinite(parsed) ? parsed : null;
@@ -1231,6 +1239,16 @@ function renderCodexSectionList(container, story) {
     const actions = document.createElement('div');
     actions.className = 'codex-task-actions';
 
+    if (entry.codexTaskUrl) {
+      const codexLink = document.createElement('a');
+      codexLink.href = entry.codexTaskUrl;
+      codexLink.className = 'button secondary';
+      codexLink.target = '_blank';
+      codexLink.rel = 'noreferrer noopener';
+      codexLink.textContent = 'Open Codex Task';
+      actions.appendChild(codexLink);
+    }
+
     if (entry.htmlUrl) {
       const openLink = document.createElement('a');
       openLink.href = entry.htmlUrl;
@@ -1257,6 +1275,13 @@ function renderCodexSectionList(container, story) {
       extraLink.rel = 'noreferrer noopener';
       extraLink.textContent = 'Latest link';
       actions.appendChild(extraLink);
+    }
+
+    if (entry.confirmationCode) {
+      const confirmation = document.createElement('p');
+      confirmation.className = 'codex-status-meta codex-confirmation';
+      confirmation.textContent = `Confirmation code: ${entry.confirmationCode}`;
+      card.appendChild(confirmation);
     }
 
     if (entry.createTrackingCard !== false) {

--- a/apps/frontend/public/styles.css
+++ b/apps/frontend/public/styles.css
@@ -1066,6 +1066,12 @@ body.is-mindmap-panning {
   color: #64748b;
 }
 
+.codex-confirmation {
+  margin-top: 0.35rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
 .codex-task-actions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- generate Codex task URLs and confirmation codes when delegating tasks, embedding them in the task brief and API response
- persist the Codex link and confirmation code in local tracking entries and display them alongside existing delegation metadata in the UI
- cover the new Codex metadata with delegation modal and server tests while keeping the server compatible with mocked fetch implementations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_690c23ee9f188333be083788dd11c3f8