### PR TITLE
AIPM: I Want To Preserve Mindmap Even Software Upgrade. The Mindmap Should Stored As Database Or

### DIFF
--- a/codewhisperer-task-1763623578923.md
+++ b/codewhisperer-task-1763623578923.md
@@ -1,0 +1,26 @@
+# AIPM: 2 I Want To Preserve Mindmap Even Software Upgrade. The Mindmap Should Stored As Database Or — Delegate to Amazon CodeWhisperer
+
+@codex
+
+# AIPM Task Brief
+Story-ID: 2
+Story-Title: I Want To Preserve Mindmap Even Software Upgrade. The Mindmap Should Stored As Database Or
+
+## Objective
+Enable the AI project manager user to Implement I Want To Preserve Mindmap Even Software Upgrade. The Mindmap Should Stored As Database Or.
+
+## Deliverables
+- Implement feature per story in branch: aipm/codewhisperer/2-i-want-to-preserve-mindmap-even-software-upgrade-the-mindma
+- Tests: unit + minimal e2e (where applicable)
+- PR back to main with title: "AIPM: I Want To Preserve Mindmap Even Software Upgrade. The Mindmap Should Stored As Database Or"
+
+## Constraints
+Use Amazon CodeWhisperer for AI-assisted development. Follow AWS best practices and ensure compatibility with existing AIPM architecture.
+
+## Acceptance Criteria
+- Then Teams can deliver measurable outcomes with shared context is completed within 2 seconds
+- And a confirmation code of at least 6 characters is recorded
+
+## Repo
+Owner/Repo: demian7575/aipm
+Default API URL: https://api.github.com/repos/demian7575/aipm


### PR DESCRIPTION
@codex

# AIPM Task Brief
Story-ID: 2
Story-Title: I Want To Preserve Mindmap Even Software Upgrade. The Mindmap Should Stored As Database Or

## Objective
Enable the AI project manager user to Implement I Want To Preserve Mindmap Even Software Upgrade. The Mindmap Should Stored As Database Or.

## Deliverables
- Implement feature per story in branch: aipm/codewhisperer/2-i-want-to-preserve-mindmap-even-software-upgrade-the-mindma
- Tests: unit + minimal e2e (where applicable)
- PR back to main with title: "AIPM: I Want To Preserve Mindmap Even Software Upgrade. The Mindmap Should Stored As Database Or"

## Constraints
Use Amazon CodeWhisperer for AI-assisted development. Follow AWS best practices and ensure compatibility with existing AIPM architecture.

## Acceptance Criteria
- Then Teams can deliver measurable outcomes with shared context is completed within 2 seconds
- And a confirmation code of at least 6 characters is recorded

## Repo
Owner/Repo: demian7575/aipm
Default API URL: https://api.github.com/repos/demian7575/aipm