### PR TITLE
I Want To Reserve Mindmap Information Even After Software Upgrade. The Mindmap Data Should Be Stored In Some Storage No…

### DIFF
--- a/codewhisperer-task-1763707150711.md
+++ b/codewhisperer-task-1763707150711.md
@@ -1,0 +1,25 @@
+# I Want To Reserve Mindmap Information Even After Software Upgrade. The Mindmap Data Should Be Stored In Some Storage No…
+
+@codex
+
+# AIPM Task Brief
+Story-ID: 2
+Story-Title: I Want To Reserve Mindmap Information Even After Software Upgrade. The Mindmap Data Should Be Stored In Some Storage No…
+
+## Objective
+As a AI project manager, I want to implement I Want To Reserve Mindmap Information Even After Software Upgrade. The Mindmap Data Should Be Stored In Some Storage not impacted by software upgrade or re-deployments. This ensures teams can deliver measurable outcomes with shared context. Focus on the Work Model and Orchestration Engagement components. This work supports the parent story "Root".
+
+## Deliverables
+- Implement feature per story in branch: i-want-to-reserve-mindmap-information-even-after-software-upgrade-the-mindmap-data-should-be-stored-in-some-storage-no
+- Tests: unit + minimal e2e (where applicable)
+- PR back to main with title: "I Want To Reserve Mindmap Information Even After Software Upgrade. The Mindmap Data Should Be Stored In Some Storage No…"
+
+## Constraints
+
+
+## Acceptance Criteria
+- I Want To Reserve Mindmap Information Even After Software Upgrade. The Mindmap Data Should Be Stored In Some Storage No… – Initial verification #1
+
+## Repo
+Owner/Repo: demian7575/aipm
+Default API URL: https://api.github.com/repos/demian7575/aipm


### PR DESCRIPTION
@codex

# AIPM Task Brief
Story-ID: 2
Story-Title: I Want To Reserve Mindmap Information Even After Software Upgrade. The Mindmap Data Should Be Stored In Some Storage No…

## Objective
As a AI project manager, I want to implement I Want To Reserve Mindmap Information Even After Software Upgrade. The Mindmap Data Should Be Stored In Some Storage not impacted by software upgrade or re-deployments. This ensures teams can deliver measurable outcomes with shared context. Focus on the Work Model and Orchestration Engagement components. This work supports the parent story "Root".

## Deliverables
- Implement feature per story in branch: i-want-to-reserve-mindmap-information-even-after-software-upgrade-the-mindmap-data-should-be-stored-in-some-storage-no
- Tests: unit + minimal e2e (where applicable)
- PR back to main with title: "I Want To Reserve Mindmap Information Even After Software Upgrade. The Mindmap Data Should Be Stored In Some Storage No…"

## Constraints


## Acceptance Criteria
- I Want To Reserve Mindmap Information Even After Software Upgrade. The Mindmap Data Should Be Stored In Some Storage No… – Initial verification #1

## Repo
Owner/Repo: demian7575/aipm
Default API URL: https://api.github.com/repos/demian7575/aipm