### PR TITLE
A “run In Staging” Button On Each PR Card In The "development Tasks" Board

### DIFF
--- a/codewhisperer-task-1764089809205.md
+++ b/codewhisperer-task-1764089809205.md
@@ -1,0 +1,25 @@
+# A “run In Staging” Button On Each PR Card In The "development Tasks" Board
+
+@codex
+
+# AIPM Task Brief
+Story-ID: 2
+Story-Title: A “run In Staging” Button On Each PR Card In The "development Tasks" Board
+
+## Objective
+As a PM, I want to implement a “Run in Staging” button on each PR card in the "Development Tasks" board. This ensures i can deploy the PR to the staging environment. Focus on the Work Model and Orchestration Engagement components. This work supports the parent story "Root".
+
+## Deliverables
+- Implement feature per story in branch: a-run-in-staging-button-on-each-pr-card-in-the-development-tasks-board
+- Tests: unit + minimal e2e (where applicable)
+- PR back to main with title: "A “run In Staging” Button On Each PR Card In The "development Tasks" Board"
+
+## Constraints
+
+
+## Acceptance Criteria
+- A “run In Staging” Button On Each PR Card In The "development Tasks" Board – Initial verification #1
+
+## Repo
+Owner/Repo: demian7575/aipm
+Default API URL: https://api.github.com/repos/demian7575/aipm


### PR DESCRIPTION
@codex

# AIPM Task Brief
Story-ID: 2
Story-Title: A “run In Staging” Button On Each PR Card In The "development Tasks" Board

## Objective
As a PM, I want to implement a “Run in Staging” button on each PR card in the "Development Tasks" board. This ensures i can deploy the PR to the staging environment. Focus on the Work Model and Orchestration Engagement components. This work supports the parent story "Root".

## Deliverables
- Implement feature per story in branch: a-run-in-staging-button-on-each-pr-card-in-the-development-tasks-board
- Tests: unit + minimal e2e (where applicable)
- PR back to main with title: "A “run In Staging” Button On Each PR Card In The "development Tasks" Board"

## Constraints


## Acceptance Criteria
- A “run In Staging” Button On Each PR Card In The "development Tasks" Board – Initial verification #1

## Repo
Owner/Repo: demian7575/aipm
Default API URL: https://api.github.com/repos/demian7575/aipm