### PR TITLE
Divide the existing "Generate Code & PR" button into two separate buttons: "Generate Code" and "Create PR". And the functionality should be separated accordingly.

### DIFF
--- a/story-1765332795702-implementation.md
+++ b/story-1765332795702-implementation.md
@@ -1,0 +1,20 @@
+# Story 1765332795702 Implementation
+
+This branch was created automatically for implementing story 1765332795702.
+
+## Next Steps
+1. Implement the required functionality
+2. Add tests
+3. Update documentation
+4. Request review
+
+## Story Details
+Title: Divide the existing "Generate Code & PR" button into two separate buttons: "Generate Code" and "Create PR". And the functionality should be separated accordingly.
+
+As a: User
+I want: Divide the existing "Generate Code & PR" button into two separate buttons: "Generate Code" and "Create PR". And the functionality should be separated accordingly. The "Generate Code" buttson should be located each "Development Task" cards, so when click the "Generate Code" button, it should AI(i.e. Kiro) generate code, run gating test(repeat fix and gating test until all gating test are passed, max iteration < 10), and then deploy to development environment
+So that: I can accomplish my goals more effectively. This work supports the parent story "AI Module Development"
+
+Description: As a User, I want to DDivide the existing "Generate Code & PR" button into two separate buttons: "Generate Code" and "Create PR". And the functionality should be separated accordingly. The "Generate Code" buttson should be located each "Development Task" cards, so when click the "Generate Code" button, it should AI(i.e. Kiro) generate code, run gating test(repeat fix and gating test until all gating test are passed, max iteration < 10), and then deploy to development environment
+
+Story Points: 3


### PR DESCRIPTION
Title: Divide the existing "Generate Code & PR" button into two separate buttons: "Generate Code" and "Create PR". And the functionality should be separated accordingly.

As a: User
I want: Divide the existing "Generate Code & PR" button into two separate buttons: "Generate Code" and "Create PR". And the functionality should be separated accordingly. The "Generate Code" buttson should be located each "Development Task" cards, so when click the "Generate Code" button, it should AI(i.e. Kiro) generate code, run gating test(repeat fix and gating test until all gating test are passed, max iteration < 10), and then deploy to development environment
So that: I can accomplish my goals more effectively. This work supports the parent story "AI Module Development"

Description: As a User, I want to DDivide the existing "Generate Code & PR" button into two separate buttons: "Generate Code" and "Create PR". And the functionality should be separated accordingly. The "Generate Code" buttson should be located each "Development Task" cards, so when click the "Generate Code" button, it should AI(i.e. Kiro) generate code, run gating test(repeat fix and gating test until all gating test are passed, max iteration < 10), and then deploy to development environment

Story Points: 3